### PR TITLE
enhanced matrix-webhook and fixed for Zabbix 7.4

### DIFF
--- a/media_types/matrix-webhook.yaml
+++ b/media_types/matrix-webhook.yaml
@@ -70,18 +70,18 @@ zabbix_export:
         // Thread replies use m.relates_to / m.thread so recovery and update
         // messages appear inside the original problem thread.
         const Matrix = {
-            // Severity color mapping
+            // severity color mapping
             severity_colors: {
                 '': 'inherit',
-                'Not classified': '#97AAB3',
-                'Information':    '#7499FF',
-                'Warning':        '#FFC859',
-                'Average':        '#FFA059',
-                'High':           '#E97659',
-                'Disaster':       '#E45959',
+                'Not classified': '#97AAB3', // Not classified - Grey
+                'Information':    '#7499FF', // Information - Blue
+                'Warning':        '#FFC859', // Warning - Yellow
+                'Average':        '#FFA059', // Average - Orange
+                'High':           '#E97659', // High - Red
+                'Disaster':       '#E45959', // Disaster - Dark Red
             },
 
-            // Severity emoji mapping
+            // severity emoji mapping
             severity_emoji: {
                 '': '',
                 'Not classified': '❓',
@@ -92,16 +92,21 @@ zabbix_export:
                 'Disaster':       '💥',
             },
 
-            // Status colors
+            // other colors
             color_problem:  '#EB0D0D',
             color_recovery: '#5FB337',
 
-            // Status emojis
+            // other emojis
             emoji_recovery: '✅',
 
             /**
-             * Log a message to the Zabbix log.
-             * Levels: 4 = debug, 3 = warning, 2 = error
+             * - 4: debug
+             * - 3: warning
+             * - 2: error
+             *
+             * @param {number} level
+             * @param {string} message
+             * @returns {string}
              */
             log: function(level, message) {
                 Zabbix.log(level, '[Matrix Webhook] ' + message);
@@ -109,41 +114,53 @@ zabbix_export:
             },
 
             /**
-             * Log an error and terminate the webhook script.
+             * Terminates webhook script.
+             *
+             * @param {number} level
+             * @param {string} message
+             * @throws {Error}
              */
             die: function(level, message) {
-                var msg = Matrix.log(level, message);
+                const msg = Matrix.log(level, message);
                 throw Error(msg);
             },
 
             /**
-             * Returns true if the macro was resolved to a non-empty value.
+             * Checks if the given macro value was resolved to a non-empty value.
+             *
+             * @param {string} macro_value resolved macro value
+             * @param {string} macro_placeholder macro placeholder `{MACRO}`
+             * @returns {boolean}
              */
             macro_has_value: function(macro_value, macro_placeholder) {
                 return macro_value !== macro_placeholder && macro_value !== '';
             },
 
             /**
-             * Parse webhook input parameters and extract send_to components.
-             * Expected format for send_to: "server_url;room_id;access_token"
+             * Parses the webhook input parameters and extracts the `{ALERT.SENDTO}` components.
+             *
+             * @param {object} value webhook input JSON
+             * @returns {object}
+             * @throws {Error}
              */
             parse_params: function(value) {
                 var params = JSON.parse(value);
 
+                // remove macro placeholder from the recipient configuration
                 if (!Matrix.macro_has_value(params.send_to, '{ALERT.SENDTO}')) {
-                    params.send_to = '';
+                    params.send_to = "";
                 }
 
-                var send_to = params.send_to.split(';');
-                params.server_url   = send_to[0] || '';
-                params.room_id      = send_to[1] || '';
-                params.access_token = send_to[2] || '';
+                const send_to = params.send_to.split(';');
+                params.server_url   = send_to[0] || "";
+                params.room_id      = send_to[1] || "";
+                params.access_token = send_to[2] || "";
                 params.api_url = params.server_url +
                     '/_matrix/client/v3/rooms/' +
                     encodeURIComponent(params.room_id) +
                     '/send/m.room.message';
 
-                if (!params.server_url || !params.room_id || !params.access_token) {
+                if (params.server_url.length === 0 || params.room_id.length === 0 || params.access_token.length === 0) {
                     Matrix.die(2, 'Missing or incomplete recipient configuration: ' + JSON.stringify({
                         server_url: params.server_url,
                         room_id: params.room_id,
@@ -154,7 +171,7 @@ zabbix_export:
                 // Resolve the stored Matrix event_id tag for thread replies.
                 // Only treat as valid if it looks like a real Matrix event_id (starts with '$').
                 // Handles unresolved macros and disabled process_tags gracefully.
-                var tag_val = params.event_tags_matrix_id || '';
+                const tag_val = params.event_tags_matrix_id || '';
                 params.matrix_thread_id = (
                     tag_val.length > 0 &&
                     tag_val !== '{EVENT.TAGS.__zbx_matrix_event_id}' &&
@@ -165,9 +182,17 @@ zabbix_export:
             },
 
             /**
-             * Post a message to a Matrix room.
+             * Posts a message to the configured Matrix recipient.
              * If thread_event_id is provided the message is sent as a thread reply.
              * Returns the parsed API response containing event_id.
+             *
+             * @param {string} url
+             * @param {string} access_token
+             * @param {string} plaintext_message usually used in notifications depending on client
+             * @param {string} formatted_message formatted message seen in chat
+             * @param {string|null} thread_event_id Matrix event_id to reply to in a thread
+             * @returns {object}
+             * @throws {Error}
              */
             post_message: function(url, access_token, plaintext_message, formatted_message, thread_event_id) {
                 var req = new HttpRequest();
@@ -175,9 +200,9 @@ zabbix_export:
                 req.addHeader('Authorization: Bearer ' + access_token);
 
                 // Use a unique transaction ID to avoid duplicate messages on retries
-                var txn_id = 'zbx_' + Date.now() + '_' + Math.floor(Math.random() * 100000);
+                const txn_id = 'zbx_' + Date.now() + '_' + Math.floor(Math.random() * 100000);
 
-                var payload = {
+                const payload = {
                     msgtype: 'm.text',
                     body: plaintext_message,
                     format: 'org.matrix.custom.html',
@@ -192,7 +217,7 @@ zabbix_export:
                     };
                 }
 
-                var response = req.put(url + '/' + txn_id, JSON.stringify(payload));
+                const response = req.put(url + '/' + txn_id, JSON.stringify(payload));
 
                 Zabbix.log(4, '[Matrix Webhook] HTTP ' + req.getStatus() + ' - ' + response);
 
@@ -203,77 +228,105 @@ zabbix_export:
                 return JSON.parse(response);
             },
 
+            /**
+             * @param {string} color
+             * @param {string} text
+             * @returns {string}
+             */
             wrap_font: function(color, text) {
                 return '<font color="' + color + '">' + text + '</font>';
             },
 
+            /**
+             * @param {string} text
+             * @returns {string}
+             */
             wrap_code: function(text) {
                 return '<code>' + text + '</code>';
             },
 
+            /**
+             * @param {string} severity
+             * @returns {string}
+             */
             get_severity_emoji: function(severity) {
                 return Matrix.wrap_font(Matrix.severity_colors[severity], Matrix.severity_emoji[severity]);
             },
 
+            /**
+             * @returns {string}
+             */
             get_recovery_emoji: function() {
                 return Matrix.wrap_font(Matrix.color_recovery, Matrix.emoji_recovery);
             },
 
+            /**
+             * @param {string} severity
+             * @param {string} label
+             * @returns {string}
+             */
             get_formatted_problem_label: function(severity, label) {
                 return Matrix.wrap_font(Matrix.severity_colors[severity], label);
             },
 
+            /**
+             * @param {string} label
+             * @returns {string}
+             */
             get_formatted_resolved_label: function(label) {
                 return Matrix.wrap_font(Matrix.color_recovery, label);
             },
 
+            /**
+             * @param {string} severity
+             * @returns {string}
+             */
             get_formatted_severity: function(severity) {
                 return Matrix.wrap_font(Matrix.severity_colors[severity], severity);
             },
         };
 
-        var params = Matrix.parse_params(value);
-        var is_problem         = params.subject === 'problem';
-        var is_service_problem = params.subject === 'service';
-        var result = {tags: {}};
+        const params = Matrix.parse_params(value);
+        const is_problem = params.subject === 'problem';
+        const is_service_problem = params.subject === 'service';
+        const result = {tags: {}};
 
         function handle_problem() {
-            var is_recovery = params.message === 'problem_recovery';
-            var is_update   = params.message === 'problem_update';
+            const is_recovery = params.message === 'problem_recovery';
+            const is_update = params.message === 'problem_update';
 
             var emoji, status_plain, status_fmt, extended_status;
 
             if (is_update) {
-                emoji           = Matrix.wrap_code(Matrix.get_severity_emoji(params.trigger_severity));
-                status_plain    = 'PROBLEM';
-                status_fmt      = Matrix.get_formatted_problem_label(params.trigger_severity, status_plain);
+                emoji = Matrix.wrap_code(Matrix.get_severity_emoji(params.trigger_severity));
+                status_plain = 'PROBLEM';
+                status_fmt = Matrix.get_formatted_problem_label(params.trigger_severity, status_plain);
                 extended_status = params.event_update_action + ' at ' + params.event_update_date + ' ' + params.event_update_time;
             } else if (is_recovery) {
-                emoji           = Matrix.wrap_code(Matrix.get_recovery_emoji());
-                status_plain    = 'RESOLVED';
-                status_fmt      = Matrix.get_formatted_resolved_label(status_plain);
+                emoji = Matrix.wrap_code(Matrix.get_recovery_emoji());
+                status_plain = 'RESOLVED';
+                status_fmt = Matrix.get_formatted_resolved_label(status_plain);
                 extended_status = 'at ' + params.event_recovery_date + ' ' + params.event_recovery_time;
             } else {
-                emoji           = Matrix.wrap_code(Matrix.get_severity_emoji(params.trigger_severity));
-                status_plain    = 'PROBLEM';
-                status_fmt      = Matrix.get_formatted_problem_label(params.trigger_severity, status_plain);
+                emoji = Matrix.wrap_code(Matrix.get_severity_emoji(params.trigger_severity));
+                status_plain = 'PROBLEM';
+                status_fmt = Matrix.get_formatted_problem_label(params.trigger_severity, status_plain);
                 extended_status = 'started at ' + params.event_date + ' ' + params.event_time;
             }
 
             var html_message =
-                '<strong>' + emoji + ' ' + status_fmt + '</strong> ' + extended_status +
-                ' (Event ID: ' + params.event_id + ')<br/>' +
+                '<strong>' + emoji + ' ' + status_fmt + '</strong> ' + extended_status + ' (Event ID: ' + params.event_id + ')<br/>' +
                 '<strong>Host:</strong> ' + Matrix.wrap_code(params.hostname) + '<br/>' +
                 '<strong>Problem:</strong> ' + Matrix.wrap_code(params.event_name) + '<br/>' +
                 '<strong>Severity: ' + Matrix.get_formatted_severity(params.trigger_severity) + '</strong><br/>';
             var plain_message =
-                status_plain + ' ' + extended_status + ' on "' + params.hostname + '": ' + params.event_name;
+                '' + status_plain + ' ' + extended_status + ' on "' + params.hostname + '": ' + params.event_name;
 
             if (is_update) {
-                var event_status_fmt = params.trigger_status === 'OK'
-                    ? Matrix.wrap_font(Matrix.color_recovery, params.event_status)
-                    : Matrix.wrap_font(Matrix.color_problem, params.event_status);
-                html_message += '<strong>Event status:</strong> ' + event_status_fmt + '<br/>';
+                const event_status = params.trigger_status === 'OK' ?
+                    Matrix.wrap_font(Matrix.color_recovery, params.event_status) :
+                    Matrix.wrap_font(Matrix.color_problem, params.event_status);
+                html_message += '<strong>Event status:</strong> ' + event_status + '<br/>';
                 html_message += '<strong>Event age:</strong> ' + params.event_age + '<br/>';
                 html_message += '<strong>Event acknowledged:</strong> ' + params.event_ack_status + '<br/>';
                 html_message += '<strong>Update message:</strong> ' + params.event_update_message + '<br/>';
@@ -294,7 +347,7 @@ zabbix_export:
 
             // For recovery and updates, reply in the original problem thread.
             // For new problems, thread_event_id is null and a new message is created.
-            var thread_id = (is_recovery || is_update) ? params.matrix_thread_id : null;
+            const thread_id = (is_recovery || is_update) ? params.matrix_thread_id : null;
 
             return Matrix.post_message(
                 params.api_url,
@@ -306,36 +359,35 @@ zabbix_export:
         }
 
         function handle_service_problem() {
-            var is_recovery = params.message === 'service_recovery';
-            var is_update   = params.message === 'service_update';
+            const is_recovery = params.message === 'service_recovery';
+            const is_update = params.message === 'service_update';
 
             var emoji, status_plain, status_fmt, extended_status;
 
             if (is_update) {
-                emoji           = Matrix.wrap_code(Matrix.get_severity_emoji(params.event_severity));
-                status_plain    = 'SERVICE PROBLEM';
-                status_fmt      = Matrix.get_formatted_problem_label(params.event_severity, status_plain);
+                emoji = Matrix.wrap_code(Matrix.get_severity_emoji(params.event_severity));
+                status_plain = 'SERVICE PROBLEM';
+                status_fmt = Matrix.get_formatted_problem_label(params.event_severity, status_plain);
                 extended_status = params.event_update_action + ' at ' + params.event_update_date + ' ' + params.event_update_time;
             } else if (is_recovery) {
-                emoji           = Matrix.wrap_code(Matrix.get_recovery_emoji());
-                status_plain    = 'SERVICE RESOLVED';
-                status_fmt      = Matrix.get_formatted_resolved_label(status_plain);
+                emoji = Matrix.wrap_code(Matrix.get_recovery_emoji());
+                status_plain = 'SERVICE RESOLVED';
+                status_fmt = Matrix.get_formatted_resolved_label(status_plain);
                 extended_status = 'at ' + params.event_recovery_date + ' ' + params.event_recovery_time;
             } else {
-                emoji           = Matrix.wrap_code(Matrix.get_severity_emoji(params.event_severity));
-                status_plain    = 'SERVICE PROBLEM';
-                status_fmt      = Matrix.get_formatted_problem_label(params.event_severity, status_plain);
+                emoji = Matrix.wrap_code(Matrix.get_severity_emoji(params.event_severity));
+                status_plain = 'SERVICE PROBLEM';
+                status_fmt = Matrix.get_formatted_problem_label(params.event_severity, status_plain);
                 extended_status = 'started at ' + params.event_date + ' ' + params.event_time;
             }
 
             var html_message =
-                '<strong>' + emoji + ' ' + status_fmt + '</strong> ' + extended_status +
-                ' (Event ID: ' + params.event_id + ')<br/>' +
+                '<strong>' + emoji + ' ' + status_fmt + '</strong> ' + extended_status + ' (Event ID: ' + params.event_id + ')<br/>' +
                 '<strong>Service:</strong> ' + Matrix.wrap_code(params.service_name) + '<br/>' +
                 '<strong>Problem:</strong> ' + Matrix.wrap_code(params.event_name) + '<br/>' +
                 '<strong>Severity: ' + Matrix.get_formatted_severity(params.event_severity) + '</strong><br/>';
             var plain_message =
-                status_plain + ' ' + extended_status + ' in service "' + params.service_name + '": ' + params.event_name;
+                '' + status_plain + ' ' + extended_status + ' in service "' + params.service_name + '": ' + params.event_name;
 
             if (Matrix.macro_has_value(params.service_rootcause, '{SERVICE.ROOTCAUSE}')) {
                 html_message += '<strong>Root cause:</strong> ' + params.service_rootcause + '<br/>';
@@ -346,10 +398,10 @@ zabbix_export:
             }
 
             if (is_update) {
-                var event_status_fmt = is_recovery
-                    ? Matrix.wrap_font(Matrix.color_recovery, params.event_status)
-                    : Matrix.wrap_font(Matrix.color_problem, params.event_status);
-                html_message += '<strong>Event status:</strong> ' + event_status_fmt + '<br/>';
+                const event_status = is_recovery ?
+                    Matrix.wrap_font(Matrix.color_recovery, params.event_status) :
+                    Matrix.wrap_font(Matrix.color_problem, params.event_status);
+                html_message += '<strong>Event status:</strong> ' + event_status + '<br/>';
                 html_message += '<strong>Event age:</strong> ' + params.event_age + '<br/>';
                 html_message += '<strong>Severity changed to:</strong> ' + params.event_update_severity + '<br/>';
             }
@@ -359,7 +411,7 @@ zabbix_export:
                 html_message += '<strong>Problem duration:</strong> ' + params.event_duration + '<br/>';
             }
 
-            var thread_id = (is_recovery || is_update) ? params.matrix_thread_id : null;
+            const thread_id = (is_recovery || is_update) ? params.matrix_thread_id : null;
 
             return Matrix.post_message(
                 params.api_url,

--- a/media_types/matrix-webhook.yaml
+++ b/media_types/matrix-webhook.yaml
@@ -38,6 +38,10 @@ zabbix_export:
           value: '{EVENT.UPDATE.SEVERITY}'
         - name: event_update_time
           value: '{EVENT.UPDATE.TIME}'
+        - name: event_tags_matrix_id
+          value: '{EVENT.TAGS.__zbx_matrix_event_id}'
+        - name: event_tags_matrix_room_id
+          value: '{EVENT.TAGS.__zbx_matrix_room_id}'
         - name: hostname
           value: '{HOST.NAME}'
         - name: message
@@ -62,20 +66,22 @@ zabbix_export:
           value: '{TRIGGER.URL}'
       max_sessions: '0'
       script: |
-        // enhanced Matrix webhook with rich formatting
+        // Enhanced Matrix webhook with rich formatting and thread support.
+        // Thread replies use m.relates_to / m.thread so recovery and update
+        // messages appear inside the original problem thread.
         const Matrix = {
-            // severity color mapping
+            // Severity color mapping
             severity_colors: {
                 '': 'inherit',
-                'Not classified': '#97AAB3', // Not classified - Grey
-                'Information':    '#7499FF', // Information - Blue
-                'Warning':        '#FFC859', // Warning - Yellow
-                'Average':        '#FFA059', // Average - Orange
-                'High':           '#E97659', // High - Red
-                'Disaster':       '#E45959', // Disaster - Dark Red
+                'Not classified': '#97AAB3',
+                'Information':    '#7499FF',
+                'Warning':        '#FFC859',
+                'Average':        '#FFA059',
+                'High':           '#E97659',
+                'Disaster':       '#E45959',
             },
-        
-            // severity emoji mapping
+
+            // Severity emoji mapping
             severity_emoji: {
                 '': '',
                 'Not classified': '❓',
@@ -85,305 +91,310 @@ zabbix_export:
                 'High':           '🔥',
                 'Disaster':       '💥',
             },
-        
-            // other colors
-            color_problem: '#EB0D0D',
+
+            // Status colors
+            color_problem:  '#EB0D0D',
             color_recovery: '#5FB337',
-        
-            // other emojis
+
+            // Status emojis
             emoji_recovery: '✅',
-        
+
             /**
-             * - 4: debug
-             * - 3: warning
-             * - 2: error
-             *
-             * @param {number} level
-             * @param {string} message
-             * @returns {string}
+             * Log a message to the Zabbix log.
+             * Levels: 4 = debug, 3 = warning, 2 = error
              */
             log: function(level, message) {
                 Zabbix.log(level, '[Matrix Webhook] ' + message);
                 return message;
             },
-        
+
             /**
-             * Terminates webhook script.
-             *
-             * @param {number} level
-             * @param {string} message
-             * @throws {Error}
+             * Log an error and terminate the webhook script.
              */
             die: function(level, message) {
-                const msg = Matrix.log(level, message);
+                var msg = Matrix.log(level, message);
                 throw Error(msg);
             },
-        
+
             /**
-             * Checks if the given macro value was resolved to a non-empty value.
-             *
-             * @param {string} macro_value resolved macro value
-             * @param {string} macro_placeholder macro placeholder `{MACRO}`
-             * @returns {boolean}
+             * Returns true if the macro was resolved to a non-empty value.
              */
             macro_has_value: function(macro_value, macro_placeholder) {
                 return macro_value !== macro_placeholder && macro_value !== '';
             },
-        
+
             /**
-             * Parses the webhook input parameters and extracts the `{ALERT.SENDTO}` components.
-             *
-             * @param {object} value webhook input JSON
-             * @returns {object}
-             * @throws {Error}
+             * Parse webhook input parameters and extract send_to components.
+             * Expected format for send_to: "server_url;room_id;access_token"
              */
             parse_params: function(value) {
                 var params = JSON.parse(value);
-        
-                // remove macro placeholder from the recipient configuration
+
                 if (!Matrix.macro_has_value(params.send_to, '{ALERT.SENDTO}')) {
-                    params.send_to = "";
+                    params.send_to = '';
                 }
-        
-                const send_to = params.send_to.split(';');
-                params.server_url = send_to[0] || "";
-                params.room_id = send_to[1] || "";
-                params.access_token = send_to[2] || "";
-                params.api_url = params.server_url + '/_matrix/client/r0/rooms/' + encodeURIComponent(params.room_id) + '/send/m.room.message?access_token=' + params.access_token;
-        
-                // logs sensitive data when enabled (use with caution)
-                // Matrix.log(4, JSON.stringify(params));
-        
-                if (params.server_url.length === 0 || params.room_id.length === 0 || params.access_token.length === 0) {
+
+                var send_to = params.send_to.split(';');
+                params.server_url   = send_to[0] || '';
+                params.room_id      = send_to[1] || '';
+                params.access_token = send_to[2] || '';
+                params.api_url = params.server_url +
+                    '/_matrix/client/v3/rooms/' +
+                    encodeURIComponent(params.room_id) +
+                    '/send/m.room.message';
+
+                if (!params.server_url || !params.room_id || !params.access_token) {
                     Matrix.die(2, 'Missing or incomplete recipient configuration: ' + JSON.stringify({
                         server_url: params.server_url,
                         room_id: params.room_id,
                         access_token_availability: params.access_token.length > 0 ? '[present]' : '[missing]',
                     }));
                 }
-        
+
+                // Resolve the stored Matrix event_id tag for thread replies.
+                // Only treat as valid if it looks like a real Matrix event_id (starts with '$').
+                // Handles unresolved macros and disabled process_tags gracefully.
+                var tag_val = params.event_tags_matrix_id || '';
+                params.matrix_thread_id = (
+                    tag_val.length > 0 &&
+                    tag_val !== '{EVENT.TAGS.__zbx_matrix_event_id}' &&
+                    tag_val.charAt(0) === '$'
+                ) ? tag_val : null;
+
                 return params;
             },
-        
+
             /**
-             * Posts a message to the configured Matrix recipient.
-             *
-             * @param {string} url
-             * @param {string} plaintext_message usually used in notifications depending on client
-             * @param {string} formatted_message formatted message seen in chat
-             * @returns {boolean}
-             * @throws {Error}
+             * Post a message to a Matrix room.
+             * If thread_event_id is provided the message is sent as a thread reply.
+             * Returns the parsed API response containing event_id.
              */
-            post_message: function(url, plaintext_message, formatted_message) {
+            post_message: function(url, access_token, plaintext_message, formatted_message, thread_event_id) {
                 var req = new HttpRequest();
                 req.addHeader('Content-Type: application/json');
-        
-                const response = req.post(url, JSON.stringify({
+                req.addHeader('Authorization: Bearer ' + access_token);
+
+                // Use a unique transaction ID to avoid duplicate messages on retries
+                var txn_id = 'zbx_' + Date.now() + '_' + Math.floor(Math.random() * 100000);
+
+                var payload = {
                     msgtype: 'm.text',
                     body: plaintext_message,
                     format: 'org.matrix.custom.html',
                     formatted_body: formatted_message,
-                }));
-        
+                };
+
+                // Attach thread relation if we have the original event_id
+                if (thread_event_id) {
+                    payload['m.relates_to'] = {
+                        rel_type: 'm.thread',
+                        event_id: thread_event_id,
+                    };
+                }
+
+                var response = req.put(url + '/' + txn_id, JSON.stringify(payload));
+
+                Zabbix.log(4, '[Matrix Webhook] HTTP ' + req.getStatus() + ' - ' + response);
+
                 if (req.getStatus() !== 200) {
                     Matrix.die(2, 'Matrix API error: HTTP ' + req.getStatus() + ' - ' + response);
                 }
-        
-                return true;
+
+                return JSON.parse(response);
             },
-        
-            /**
-             * @param {string} color
-             * @param {string} text
-             * @returns {string}
-             */
+
             wrap_font: function(color, text) {
                 return '<font color="' + color + '">' + text + '</font>';
             },
-        
-            /**
-             * @param {string} text
-             * @returns {string}
-             */
+
             wrap_code: function(text) {
                 return '<code>' + text + '</code>';
             },
-        
-            /**
-             * @param {string} severity
-             * @returns {string}
-             */
+
             get_severity_emoji: function(severity) {
                 return Matrix.wrap_font(Matrix.severity_colors[severity], Matrix.severity_emoji[severity]);
             },
-        
-            /**
-             * @returns {string}
-             */
+
             get_recovery_emoji: function() {
                 return Matrix.wrap_font(Matrix.color_recovery, Matrix.emoji_recovery);
             },
-        
-            /**
-             * @param {string} severity
-             * @param {string} label
-             * @returns {string}
-             */
+
             get_formatted_problem_label: function(severity, label) {
                 return Matrix.wrap_font(Matrix.severity_colors[severity], label);
             },
-        
-            /**
-             * @param {string} label
-             * @returns {string}
-             */
+
             get_formatted_resolved_label: function(label) {
                 return Matrix.wrap_font(Matrix.color_recovery, label);
             },
-        
-            /**
-             * @param {string} severity
-             * @returns {string}
-             */
+
             get_formatted_severity: function(severity) {
                 return Matrix.wrap_font(Matrix.severity_colors[severity], severity);
             },
         };
-        
-        const params = Matrix.parse_params(value);
-        const is_problem = params.subject === 'problem';
-        const is_service_problem = params.subject === 'service';
-        
+
+        var params = Matrix.parse_params(value);
+        var is_problem         = params.subject === 'problem';
+        var is_service_problem = params.subject === 'service';
+        var result = {tags: {}};
+
         function handle_problem() {
-            const is_recovery = params.message === 'problem_recovery';
-            const is_update = params.message === 'problem_update';
-        
+            var is_recovery = params.message === 'problem_recovery';
+            var is_update   = params.message === 'problem_update';
+
             var emoji, status_plain, status_fmt, extended_status;
-        
+
             if (is_update) {
-                emoji = Matrix.wrap_code(Matrix.get_severity_emoji(params.trigger_severity));
-                status_plain = 'PROBLEM';
-                status_fmt = Matrix.get_formatted_problem_label(params.trigger_severity, status_plain);
+                emoji           = Matrix.wrap_code(Matrix.get_severity_emoji(params.trigger_severity));
+                status_plain    = 'PROBLEM';
+                status_fmt      = Matrix.get_formatted_problem_label(params.trigger_severity, status_plain);
                 extended_status = params.event_update_action + ' at ' + params.event_update_date + ' ' + params.event_update_time;
             } else if (is_recovery) {
-                emoji = Matrix.wrap_code(Matrix.get_recovery_emoji());
-                status_plain = 'RESOLVED';
-                status_fmt = Matrix.get_formatted_resolved_label(status_plain);
+                emoji           = Matrix.wrap_code(Matrix.get_recovery_emoji());
+                status_plain    = 'RESOLVED';
+                status_fmt      = Matrix.get_formatted_resolved_label(status_plain);
                 extended_status = 'at ' + params.event_recovery_date + ' ' + params.event_recovery_time;
             } else {
-                emoji = Matrix.wrap_code(Matrix.get_severity_emoji(params.trigger_severity));
-                status_plain = 'PROBLEM';
-                status_fmt = Matrix.get_formatted_problem_label(params.trigger_severity, status_plain);
+                emoji           = Matrix.wrap_code(Matrix.get_severity_emoji(params.trigger_severity));
+                status_plain    = 'PROBLEM';
+                status_fmt      = Matrix.get_formatted_problem_label(params.trigger_severity, status_plain);
                 extended_status = 'started at ' + params.event_date + ' ' + params.event_time;
             }
-        
+
             var html_message =
-                '<strong>' + emoji + ' ' + status_fmt + '</strong> ' + extended_status + ' (Event ID: ' + params.event_id + ')<br/>' +
+                '<strong>' + emoji + ' ' + status_fmt + '</strong> ' + extended_status +
+                ' (Event ID: ' + params.event_id + ')<br/>' +
                 '<strong>Host:</strong> ' + Matrix.wrap_code(params.hostname) + '<br/>' +
                 '<strong>Problem:</strong> ' + Matrix.wrap_code(params.event_name) + '<br/>' +
                 '<strong>Severity: ' + Matrix.get_formatted_severity(params.trigger_severity) + '</strong><br/>';
             var plain_message =
-                '' + status_plain + ' ' + extended_status + ' on "' + params.hostname + '": ' + params.event_name;
-        
+                status_plain + ' ' + extended_status + ' on "' + params.hostname + '": ' + params.event_name;
+
             if (is_update) {
-                const event_status = params.trigger_status === 'OK' ?
-                    Matrix.wrap_font(Matrix.color_recovery, params.event_status) :
-                    Matrix.wrap_font(Matrix.color_problem, params.event_status);
-                html_message += '<strong>Event status:</strong> ' + event_status + '<br/>';
+                var event_status_fmt = params.trigger_status === 'OK'
+                    ? Matrix.wrap_font(Matrix.color_recovery, params.event_status)
+                    : Matrix.wrap_font(Matrix.color_problem, params.event_status);
+                html_message += '<strong>Event status:</strong> ' + event_status_fmt + '<br/>';
                 html_message += '<strong>Event age:</strong> ' + params.event_age + '<br/>';
                 html_message += '<strong>Event acknowledged:</strong> ' + params.event_ack_status + '<br/>';
                 html_message += '<strong>Update message:</strong> ' + params.event_update_message + '<br/>';
             }
-        
+
             if (is_recovery) {
                 html_message += '<strong>Original problem time:</strong> ' + params.event_date + ' ' + params.event_time + '<br/>';
                 html_message += '<strong>Problem duration:</strong> ' + params.event_duration + '<br/>';
             }
-        
+
             if (Matrix.macro_has_value(params.event_opdata, '{EVENT.OPDATA}')) {
                 html_message += '<strong>Operational data:</strong> ' + Matrix.wrap_code(params.event_opdata) + '<br/>';
             }
-        
+
             if (Matrix.macro_has_value(params.trigger_url, '{TRIGGER.URL}')) {
                 html_message += '<strong>Details:</strong> ' + params.trigger_url + '<br/>';
             }
-        
-            // Matrix.log(4, 'HTML: ' + html_message);
-            // Matrix.log(4, 'Plain: ' + plain_message);
-        
-            Matrix.post_message(params.api_url, plain_message, html_message + '<br/>');
+
+            // For recovery and updates, reply in the original problem thread.
+            // For new problems, thread_event_id is null and a new message is created.
+            var thread_id = (is_recovery || is_update) ? params.matrix_thread_id : null;
+
+            return Matrix.post_message(
+                params.api_url,
+                params.access_token,
+                plain_message,
+                html_message + '<br/>',
+                thread_id
+            );
         }
-        
+
         function handle_service_problem() {
-            const is_recovery = params.message === 'service_recovery';
-            const is_update = params.message === 'service_update';
-        
+            var is_recovery = params.message === 'service_recovery';
+            var is_update   = params.message === 'service_update';
+
             var emoji, status_plain, status_fmt, extended_status;
-        
+
             if (is_update) {
-                emoji = Matrix.wrap_code(Matrix.get_severity_emoji(params.event_severity));
-                status_plain = 'SERVICE PROBLEM';
-                status_fmt = Matrix.get_formatted_problem_label(params.event_severity, status_plain);
+                emoji           = Matrix.wrap_code(Matrix.get_severity_emoji(params.event_severity));
+                status_plain    = 'SERVICE PROBLEM';
+                status_fmt      = Matrix.get_formatted_problem_label(params.event_severity, status_plain);
                 extended_status = params.event_update_action + ' at ' + params.event_update_date + ' ' + params.event_update_time;
             } else if (is_recovery) {
-                emoji = Matrix.wrap_code(Matrix.get_recovery_emoji());
-                status_plain = 'SERVICE RESOLVED';
-                status_fmt = Matrix.get_formatted_resolved_label(status_plain);
+                emoji           = Matrix.wrap_code(Matrix.get_recovery_emoji());
+                status_plain    = 'SERVICE RESOLVED';
+                status_fmt      = Matrix.get_formatted_resolved_label(status_plain);
                 extended_status = 'at ' + params.event_recovery_date + ' ' + params.event_recovery_time;
             } else {
-                emoji = Matrix.wrap_code(Matrix.get_severity_emoji(params.event_severity));
-                status_plain = 'SERVICE PROBLEM';
-                status_fmt = Matrix.get_formatted_problem_label(params.event_severity, status_plain);
+                emoji           = Matrix.wrap_code(Matrix.get_severity_emoji(params.event_severity));
+                status_plain    = 'SERVICE PROBLEM';
+                status_fmt      = Matrix.get_formatted_problem_label(params.event_severity, status_plain);
                 extended_status = 'started at ' + params.event_date + ' ' + params.event_time;
             }
-        
+
             var html_message =
-                '<strong>' + emoji + ' ' + status_fmt + '</strong> ' + extended_status + ' (Event ID: ' + params.event_id + ')<br/>' +
+                '<strong>' + emoji + ' ' + status_fmt + '</strong> ' + extended_status +
+                ' (Event ID: ' + params.event_id + ')<br/>' +
                 '<strong>Service:</strong> ' + Matrix.wrap_code(params.service_name) + '<br/>' +
                 '<strong>Problem:</strong> ' + Matrix.wrap_code(params.event_name) + '<br/>' +
                 '<strong>Severity: ' + Matrix.get_formatted_severity(params.event_severity) + '</strong><br/>';
             var plain_message =
-                '' + status_plain + ' ' + extended_status + ' in service "' + params.service_name + '": ' + params.event_name;
-        
+                status_plain + ' ' + extended_status + ' in service "' + params.service_name + '": ' + params.event_name;
+
             if (Matrix.macro_has_value(params.service_rootcause, '{SERVICE.ROOTCAUSE}')) {
                 html_message += '<strong>Root cause:</strong> ' + params.service_rootcause + '<br/>';
             }
-        
+
             if (params.service_description) {
                 html_message += '<strong>Description:</strong> ' + params.service_description + '<br/>';
             }
-        
+
             if (is_update) {
-                const event_status = is_recovery ?
-                    Matrix.wrap_font(Matrix.color_recovery, params.event_status) :
-                    Matrix.wrap_font(Matrix.color_problem, params.event_status);
-                html_message += '<strong>Event status:</strong> ' + event_status + '<br/>';
+                var event_status_fmt = is_recovery
+                    ? Matrix.wrap_font(Matrix.color_recovery, params.event_status)
+                    : Matrix.wrap_font(Matrix.color_problem, params.event_status);
+                html_message += '<strong>Event status:</strong> ' + event_status_fmt + '<br/>';
                 html_message += '<strong>Event age:</strong> ' + params.event_age + '<br/>';
                 html_message += '<strong>Severity changed to:</strong> ' + params.event_update_severity + '<br/>';
             }
-        
+
             if (is_recovery) {
                 html_message += '<strong>Original problem time:</strong> ' + params.event_date + ' ' + params.event_time + '<br/>';
                 html_message += '<strong>Problem duration:</strong> ' + params.event_duration + '<br/>';
             }
-        
-            // Matrix.log(4, 'HTML: ' + html_message);
-            // Matrix.log(4, 'Plain: ' + plain_message);
-        
-            Matrix.post_message(params.api_url, plain_message, html_message + '<br/>');
+
+            var thread_id = (is_recovery || is_update) ? params.matrix_thread_id : null;
+
+            return Matrix.post_message(
+                params.api_url,
+                params.access_token,
+                plain_message,
+                html_message + '<br/>',
+                thread_id
+            );
         }
-        
+
+        var resp;
         if (is_problem) {
-            handle_problem();
+            resp = handle_problem();
         } else if (is_service_problem) {
-            handle_service_problem();
+            resp = handle_service_problem();
         } else {
             Matrix.die(2, 'Unsupported event received.');
         }
-        
-        return 'OK';
+
+        // Store the Matrix event_id and room_id of the initial PROBLEM message as
+        // Zabbix event tags so that recovery/update messages can reply in the same
+        // thread and the event menu entry can link directly to the Matrix message.
+        if (resp && resp.event_id) {
+            result.tags.__zbx_matrix_event_id = resp.event_id;
+            result.tags.__zbx_matrix_room_id  = params.room_id;
+        }
+
+        return JSON.stringify(result);
       process_tags: 'YES'
-      description: 'Format for {ALERT.SENDTO} parameter: "server_url;room_id;access_token" (without quotes)'
+      show_event_menu: 'YES'
+      event_menu_name: 'Open in Matrix'
+      event_menu_url: 'https://matrix.to/#/{EVENT.TAGS.__zbx_matrix_room_id}/{EVENT.TAGS.__zbx_matrix_event_id}'
+      description: |
+        Format for {ALERT.SENDTO}: "https://matrix.example.org;!roomid:example.org;access_token" (without quotes)
+        Menu entry URL (optional): https://matrix.to/#/{EVENT.TAGS.__zbx_matrix_room_id}/{EVENT.TAGS.__zbx_matrix_event_id}
       message_templates:
         - event_source: TRIGGERS
           operation_mode: PROBLEM


### PR DESCRIPTION
Fix: JSON output instead just 'OK' so it works with Zabbix 7.4.9
Added: answers with resolved message in threaded chat (disable by unchecking "Process tags" in media-type settings)
Added: optional "Menu entry name" with "Menu entry URL" to matrix room and event tag
Note: created with AI (Claude) - tested successfully on fresh install of Zabbix 7.4.9